### PR TITLE
Decrease picker radius and add channel picker state

### DIFF
--- a/curl/run_curl.py
+++ b/curl/run_curl.py
@@ -73,6 +73,8 @@ def main():
     parser.add_argument('--env_kwargs_observation_mode', default='only_depth', type=str)  # Should be in ['key_point', 'cam_rgb', 'point_cloud', 'img_depth', 'only_depth']
     parser.add_argument('--env_kwargs_num_variations', default=10, type=int)
 
+    parser.add_argument('--env_kwargs_use_pick_old_state', default = True, type=bool)
+
     args = parser.parse_args()
 
     args.algorithm = 'CURL'

--- a/curl/train.py
+++ b/curl/train.py
@@ -213,14 +213,16 @@ def main(args):
 
     if args.encoder_type == 'pixel':
         if args.env_kwargs['observation_mode'] == 'cam_rgb':
-            obs_shape = (3, args.image_size, args.image_size)
-            pre_aug_obs_shape = (3, args.pre_transform_image_size, args.pre_transform_image_size)
+            n = 3
         elif args.env_kwargs['observation_mode'] == 'only_depth':
-            obs_shape = (1, args.image_size, args.image_size)
-            pre_aug_obs_shape = (1, args.pre_transform_image_size, args.pre_transform_image_size)
+            n = 1
         else:
-            obs_shape = (4, args.image_size, args.image_size)
-            pre_aug_obs_shape = (4, args.pre_transform_image_size, args.pre_transform_image_size)
+            n = 4
+
+        if args.env_kwargs['use_pick_old_state']:
+            n+=args.env_kwargs['num_picker']
+        obs_shape = (n, args.image_size, args.image_size)
+        pre_aug_obs_shape = (n, args.pre_transform_image_size, args.pre_transform_image_size)
     else:
         obs_shape = env.observation_space.shape
         pre_aug_obs_shape = obs_shape

--- a/equi/run_equi.py
+++ b/equi/run_equi.py
@@ -69,8 +69,11 @@ def main():
     # Override environment arguments
     parser.add_argument('--env_kwargs_render', default=True, type=bool)  # Turn off rendering can speed up training
     parser.add_argument('--env_kwargs_camera_name', default='default_camera', type=str)
-    parser.add_argument('--env_kwargs_observation_mode', default='cam_rgb', type=str)  # Should be in ['key_point', 'cam_rgb', 'point_cloud']
+    parser.add_argument('--env_kwargs_observation_mode', default='only_depth', type=str)  # Should be in ['key_point', 'cam_rgb', 'point_cloud']
     parser.add_argument('--env_kwargs_num_variations', default=10, type=int)
+
+    parser.add_argument('--env_kwargs_use_pick_old_state', default = True, type=bool)
+
 
     args = parser.parse_args()
     args.algorithm = 'EQUI'

--- a/equi/train.py
+++ b/equi/train.py
@@ -213,12 +213,16 @@ def main(args):
     action_shape = env.action_space.shape
     if args.encoder_type == 'pixel':
         if args.env_kwargs['observation_mode'] == 'cam_rgb':
-            obs_shape = (3, args.image_size, args.image_size)
+            n = 3
         elif args.env_kwargs['observation_mode'] == 'only_depth':
-            obs_shape = (1, args.image_size, args.image_size)
+            n = 1
         else:
-            obs_shape = (4, args.image_size, args.image_size)
-        pre_aug_obs_shape = obs_shape
+            n = 4
+
+        if args.env_kwargs['use_pick_old_state']:
+            n+=args.env_kwargs['num_picker']
+        obs_shape = (n, args.image_size, args.image_size)
+        pre_aug_obs_shape = (n, args.pre_transform_image_size, args.pre_transform_image_size)
     else:
         obs_shape = env.observation_space.shape
         pre_aug_obs_shape = obs_shape


### PR DESCRIPTION
- Giảm bán kính xuống một nửa còn 0.0025
- Thêm số kênh mới vào đầu vào ban đầu bằng số picker, set env_kwargs_use_pick_old_state
- Khi số kênh ảnh + số picker > 4 bị lỗi resize ảnh. Nên tách ra resize ảnh RGB trước sau đó torch.cat với ảnh picked
- Sửa lại thuật toán resize là cv2.INTER_AREA phù hợp hơn cho phép nén ảnh